### PR TITLE
Double errors issue

### DIFF
--- a/lib/performify/base.rb
+++ b/lib/performify/base.rb
@@ -75,6 +75,7 @@ module Performify
     private def prepare_instance
       define_singleton_method(:execute!) do |&block|
         return if defined?(@result)
+
         super(&block)
       end
 

--- a/lib/performify/base.rb
+++ b/lib/performify/base.rb
@@ -32,7 +32,7 @@ module Performify
             fail!(with_callbacks: false)
           end
         rescue RuntimeError, ActiveRecord::RecordInvalid => e
-          fail!(exception: e)
+          fail!(exception: e, with_callbacks: false)
         end
 
         raise ActiveRecord::Rollback if fail?

--- a/lib/performify/callbacks.rb
+++ b/lib/performify/callbacks.rb
@@ -12,6 +12,7 @@ module Performify
       unless TYPES_OF_CALLBACK.include?(type_of_callback)
         raise UnknownTypeOfCallbackError, "Type #{type_of_callback} is not allowed"
       end
+
       @service_callbacks ||= {}
       @service_callbacks[type_of_callback] ||= []
       @service_callbacks[type_of_callback] << method_name if method_name
@@ -23,6 +24,7 @@ module Performify
       unless TYPES_OF_CALLBACK.include?(type_of_callback)
         raise UnknownTypeOfCallbackError, "Type #{type_of_callback} is not allowed"
       end
+
       cbs = (@service_callbacks || {}).fetch(type_of_callback, [])
       cbs.each { |cb| cb.is_a?(Proc) ? instance.instance_eval(&cb) : instance.send(cb) }
       nil

--- a/lib/performify/validation.rb
+++ b/lib/performify/validation.rb
@@ -26,6 +26,7 @@ module Performify
 
       def validate
         return args if schema.nil?
+
         result = schema.with(with_options).call(args)
         if result.success?
           @inputs = result.output
@@ -37,6 +38,7 @@ module Performify
 
       def errors!(new_errors)
         raise ArgumentError, 'Errors should be a hash' if new_errors.nil? || !new_errors.respond_to?(:to_h)
+
         new_errors.to_h.each do |key, value|
           errors[key] = errors.key?(key) ? [errors[key]].flatten(1) + [value].flatten(1) : value
         end

--- a/lib/performify/version.rb
+++ b/lib/performify/version.rb
@@ -1,3 +1,3 @@
 module Performify
-  VERSION = '0.9.0'.freeze
+  VERSION = '0.9.1'.freeze
 end

--- a/spec/lib/performify/execute_spec.rb
+++ b/spec/lib/performify/execute_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe Performify::Base do
       end.to yield_control
     end
 
+    context 'when execution raises ActiveRecord::RecordInvalid' do
+      it 'calls registered fail callback only once' do
+        expect do |b|
+          described_class.register_callback(:fail, &b)
+          subject.execute! { raise ActiveRecord::RecordInvalid }
+        end.to yield_control.once
+      end
+    end
+
     context 'when execution has been already performed' do
       it 'performes execution only once' do
         expect do |b|


### PR DESCRIPTION
If exception raised (specifically `ActiveRecord::RecordInvalid`) we were calling fail block twice. Fixed it by disabling callbacks in rescue. They will be called later, because service has failed.