### PR TITLE
Respect execution specified inside of block

### DIFF
--- a/lib/performify/base.rb
+++ b/lib/performify/base.rb
@@ -26,10 +26,13 @@ module Performify
       ActiveRecord::Base.transaction do
         begin
           block_result = yield
-          if block_result
-            success!(with_callbacks: false)
-          else
-            fail!(with_callbacks: false)
+
+          if @result.nil?
+            if block_result
+              success!(with_callbacks: false)
+            else
+              fail!(with_callbacks: false)
+            end
           end
         rescue RuntimeError, ActiveRecord::RecordInvalid => e
           fail!(exception: e, with_callbacks: false)

--- a/spec/lib/performify/execute_spec.rb
+++ b/spec/lib/performify/execute_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe Performify::Base do
       end.to yield_control
     end
 
+    context "when result has been specified by block" do
+      it "does not replace it by result specified based on block return value" do
+        subject.execute! do
+          subject.success!
+          false
+        end
+
+        expect(subject.success?).to be true
+      end
+    end
+
     context 'when execution raises ActiveRecord::RecordInvalid' do
       it 'calls registered fail callback only once' do
         expect do |b|


### PR DESCRIPTION
## Description

When result of execution has been specified inside of block it doesn't replaced by block return value.