### PR TITLE
Switched to dry-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## 1.0.0
+
+This version is switching performify from version `0.12.0` of `dry-validation` to `dry-schema` of version `1.4` which means breaking changes:
+
+- Because additional options are not supported by `dry-schema` (or at least I have not found this support in the source code) we were forced to drop them as well. So, from now you can't use `current_user` in your schemas by default because it's not being passed implicitly.

--- a/README.md
+++ b/README.md
@@ -242,32 +242,6 @@ else
 end
 ```
 
-You can set options for `#with` to schema by overriding `#with_options`.
-By default `#with_options` contains `{ current_user: current_user }`.
-
-```ruby
-module Users
-  class UpdatePassword < ApplicationService
-    schema do
-      configure do
-        option :current_user
-
-        def valid_password?(value)
-          current_user.password_digest.blank? || current_user.authenticate(value)
-        end
-      end
-
-      optional(:old_password).filled(:str?, :valid_password?)
-      required(:new_password).filled(:str?)
-    end
-
-    def execute!
-      super { current_user.update(password: new_password) }
-    end
-  end
-end
-```
-
 You can get filtered inputs after success validation by accessing `inputs`.
 
 ```ruby

--- a/lib/performify.rb
+++ b/lib/performify.rb
@@ -1,3 +1,5 @@
+require "dry/schema"
+
 require "performify/version"
 require "performify/base"
 

--- a/lib/performify/validation.rb
+++ b/lib/performify/validation.rb
@@ -1,5 +1,3 @@
-require 'dry-validation'
-
 module Performify
   module Validation
     def self.extended(base)
@@ -10,8 +8,8 @@ module Performify
     module ClassMethods
       def schema(outer_schema = nil, &block)
         if block_given?
-          @schema = Dry::Validation.Schema(Dry::Validation::Schema::Params, {}, &block)
-        elsif outer_schema.present? && outer_schema.is_a?(Dry::Validation::Schema)
+          @schema = Dry::Schema.Params({}, &block)
+        elsif outer_schema.present? && outer_schema.is_a?(Dry::Schema::Params)
           @schema = outer_schema
         else
           @schema
@@ -27,7 +25,8 @@ module Performify
       def validate
         return args if schema.nil?
 
-        result = schema.with(with_options).call(args)
+        result = schema.call(args)
+
         if result.success?
           @inputs = result.output
         else
@@ -50,10 +49,6 @@ module Performify
 
       def errors?
         errors.any?
-      end
-
-      private def with_options
-        { current_user: current_user }
       end
     end
   end

--- a/lib/performify/version.rb
+++ b/lib/performify/version.rb
@@ -1,3 +1,3 @@
 module Performify
-  VERSION = '0.11.0'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/performify.gemspec
+++ b/performify.gemspec
@@ -23,10 +23,10 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 4.0.0"
-  spec.add_dependency "dry-validation", ">= 0.12.0"
+  spec.add_dependency "activerecord", ">= 4.0"
+  spec.add_dependency "dry-schema", "~> 1.4"
 
-  spec.add_development_dependency "sqlite3", "~> 1.3.13"
+  spec.add_development_dependency "sqlite3", "~> 1.4"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5"

--- a/spec/lib/performify/validation_spec.rb
+++ b/spec/lib/performify/validation_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Performify::Base do
 
     context 'with outer schema' do
       let(:klass) do
-        outer_schema = Dry::Validation.Schema do
+        outer_schema = Dry::Schema.Params do
           required(:foo).filled(:str?)
         end
 
@@ -164,94 +164,6 @@ RSpec.describe Performify::Base do
         it 'no filtered inputs' do
           subject.execute!
           expect(subject.inputs).to be_nil
-        end
-      end
-    end
-
-    context '#with_options' do
-      let(:user) { double(:user, foo: 'bar') }
-
-      let(:klass) do
-        Class.new(described_class) do
-          schema do
-            configure do
-              option :current_user
-
-              def self.messages
-                super.merge(en: { errors: { valid?: 'foo invalid' } })
-              end
-
-              def valid?(value)
-                current_user.foo == value
-              end
-            end
-
-            required(:foo).filled(:str?, :valid?)
-          end
-
-          def execute!
-            super { true }
-          end
-        end
-      end
-
-      context 'foo valid' do
-        it 'no errors' do
-          expect(subject.errors).to eq({})
-        end
-      end
-
-      context 'foo invalid' do
-        let(:user) { double(:user, foo: 'bar_foo') }
-
-        it 'should return error' do
-          expect(subject.errors).to eq({ foo: ['foo invalid'] })
-        end
-      end
-
-      context 'override' do
-        let(:klass) do
-          Class.new(described_class) do
-            schema do
-              configure do
-                option :user
-
-                def self.messages
-                  super.merge(en: { errors: { valid?: 'foo invalid' } })
-                end
-
-                def valid?(value)
-                  user.foo == value
-                end
-              end
-
-              required(:foo).filled(:str?, :valid?)
-            end
-
-            def execute!
-              super { true }
-            end
-
-            private
-
-            def with_options
-              { user: current_user}
-            end
-          end
-        end
-
-        context 'foo valid' do
-          it 'no errors' do
-            expect(subject.errors).to eq({})
-          end
-        end
-
-        context 'foo invalid' do
-          let(:user) { double(:user, foo: 'bar_foo') }
-
-          it 'should return error' do
-            expect(subject.errors).to eq({ foo: ['foo invalid'] })
-          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ Bundler.setup
 
 require 'active_record'
 require 'performify'
+require 'byebug'
 
 ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
 


### PR DESCRIPTION
## Description

This PR is switching `performify` to `dry-schema`. Because of API incompatibility with `dry-validation` we are forced to drop support of implicit parameter called `current_user` in schemas and release major version.

## References

- https://github.com/trickstersio/performify/issues/32
- https://github.com/trickstersio/performify/issues/31
 